### PR TITLE
Update non-working SentinelOne install script

### DIFF
--- a/PowerShell/Scripts/Security-Apps/SentinelOne/Install SentinelOne.ps1
+++ b/PowerShell/Scripts/Security-Apps/SentinelOne/Install SentinelOne.ps1
@@ -48,7 +48,7 @@ vssadmin Resize ShadowStorage /For=C: /On=C: /MaxSize=10%
 
 #Download the installer
 $ProgressPreference = 'SilentlyContinue'
-iwr -uri https://github.com/levelsoftware/scripts/raw/main/PowerShell/Security-Apps/SentinelOne/$S1_File -outfile $Installer
+iwr -uri https://github.com/levelrmm/scripts/raw/main/PowerShell/Scripts/Security-Apps/SentinelOne/$S1_File -outfile $Installer
 $FileSize = [math]::round((Get-Item -Path $Installer).Length / 1MB, 2)
 "Downloaded $Installer - $FileSize MB"
 


### PR DESCRIPTION
Fixed download uri, it was referencing an old link where main repo came from "levelsoftware" rather than "levelrmm", as well as different directory. 